### PR TITLE
Support for https (SSL) missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+1.  git clone https://github.com/lemmy/lyxblogger.git
+
+2.  rm -f INSTALL/lyxblogger.py && cd src/ && ./coalesce.py seed.py \> ../INSTALL/lyxblogger.py
+
+3.  cd INSTALL/ && sudo python setup-no-elyxer.py install
+
+4.  LyX: Tools \> Reconfigure & restart once
+
+

--- a/src/LyxBlog/image.py
+++ b/src/LyxBlog/image.py
@@ -40,7 +40,7 @@ def find_local_image_tag(in_html, ELYXER_ENGINE):
         img_exp = re.compile('''
             <img\ class="embedded"\          # The beginning of an <img> tag -- note two escaped spaces
             src="           # Note use of double quotes instead of single
-            (?!http://)     # Negative lookahead expression (if it has http:// it's already been changed to web reference)
+            (?!(http|https)://)     # Negative lookahead expression (if it has http:// or https:// it's already been changed to web reference)
             ..*?            # Non-greedy (short as possible match) of stuff in middle
             />              # The closing of the <img> tag
             ''', re.VERBOSE)
@@ -49,7 +49,7 @@ def find_local_image_tag(in_html, ELYXER_ENGINE):
     # <img src='0_home_jd_Escritorio_rv-8_tiny.jpg' alt='image: 0_home_jd_Escritorio_rv-8_tiny.jpg' />
         img_exp = re.compile('''
             <img\ src='     # The beginning of an <img> tag -- note the escaped space in the verbose regex
-            (?!http://)     # Negative lookahead expression (if it has http:// it's already been changed to web reference)
+            (?!(http|https)://)     # Negative lookahead expression (if it has http:// or https:// it's already been changed to web reference)
             ..*?            # Non-greedy (short as possible match) of stuff in middle
             />              # The closing of the <img> tag
             ''', re.VERBOSE)
@@ -80,10 +80,10 @@ def up_images(in_html, wp_client_obj, ELYXER_ENGINE, in_DIR_OFFSET):
         except (gaierror, WordPressException):
             handle_gaierror()
         try:
-            assert(imageSrc.startswith('http://'))
+            assert(imageSrc.startswith('http://') or imageSrc.startswith('https://'))
         except AssertionError:
             print("There was a problem uploading your image.")
-            print("imageSrc should start with http://")
+            print("imageSrc should start with http:// or https://")
             print("Please contact the author at jackdesert@gmail.com")
             handle_general_error()
         try:

--- a/src/LyxBlog/profiles.py
+++ b/src/LyxBlog/profiles.py
@@ -257,15 +257,13 @@ class Credentials:
         pr3 ("\nURL")
         while (1):
             pr3 ("Please enter your WordPress URL")
-            pr3 ("Example: cool_site.wordpress.com")
+            pr3 ("Example: http://cool_site.wordpress.com or https://cool_site.wordpress.com")
             url = sys.stdin.readline().replace('\n', '')
             if url != '': break
-        url = url.replace('http://', '')
-        url = url.replace('www.', '')
         if url.endswith('/'):
-            url = 'http://' + url + 'xmlrpc.php'
+            url = url + 'xmlrpc.php'
         else:
-            url = 'http://' + url + '/xmlrpc.php'
+            url = url + '/xmlrpc.php'
         pr3 ("The PhP page we'll be talking to is " + url)
         pr3 ("\nPROMPT for PASSWORD?")
         pr3 ("Press ENTER now to be prompted each time (recommended).")


### PR DESCRIPTION
It seems as if lyxblogger is missing support for https. The new profile wizard doesn't accept https://... and fails to verify the URL even when the webserver running the blog redirects from http to https. Manually creating the config for a blog hosted with https seems to do the trick though at first, but then fails to upload images (lyxBlogger.py line 240 checks for "http").
